### PR TITLE
chore: set repository url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
     "compression",
     "slimcontext"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/agentailor/slimcontext-mcp-server"
+  },
   "author": "SlimContext MCP Server",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This PR sets the `repository` field in `package.json` to the correct GitHub URL:

https://github.com/agentailor/slimcontext-mcp-server

This helps NPM link back to the source repository when publishing.